### PR TITLE
fix: Ignores codecov errors to make CI pass

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,4 +32,4 @@ jobs:
         # Repository upload token - get it from codecov.io. Required only for private repositories
         token: ${{ secrets.CODECOV_TOKEN }}
         # Specify whether or not CI build should fail if Codecov runs into an error during upload
-        fail_ci_if_error: true
+        fail_ci_if_error: false


### PR DESCRIPTION
Reference : https://github.com/codecov/codecov-action/issues/81
